### PR TITLE
Add node_modules folder to gitignore

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "build": "npm install && npx webpack",
-    "launch": "npm install && npx webpack serve"
+    "build": "npm run build",
+    "launch": "npm run dev"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -105,7 +105,9 @@
     "wildcard": "^2.0.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "webpack",
+    "dev": "webpack serve"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Add `node_modules` folder to `.gitignore` and update build and dev commands.

* Add `node_modules/` to `.gitignore` file to ignore the `node_modules` folder.
* Add `build` and `dev` scripts to `package.json`.
  * `"build": "webpack"`
  * `"dev": "webpack serve"`
* Update `.devcontainer.json` to include `build` and `dev` tasks as npm scripts.
  * `"build": "npm run build"`
  * `"launch": "npm run dev"`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ggindev/domain-pro-check?shareId=1f85544a-d43a-48c2-95f0-fd385589f314).